### PR TITLE
feat: add callback parameter to `serve` functions

### DIFF
--- a/packages/vike-server/src/handlers/adapters/serve/bun/elysia.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/bun/elysia.ts
@@ -1,6 +1,10 @@
 import type { apply as applyAdapter } from '@universal-middleware/elysia'
-import { onReady, type ServerOptionsBase } from '../../../serve.js'
+import { type Callback, onReady, type ServerOptionsBase } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptionsBase) {
-  return app.listen(options.port, onReady(options))
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptionsBase,
+  callback?: Callback
+) {
+  return app.listen(options.port, onReady({ callback, ...options }))
 }

--- a/packages/vike-server/src/handlers/adapters/serve/bun/h3.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/bun/h3.ts
@@ -1,9 +1,13 @@
 import type { apply as applyAdapter } from '@universal-middleware/h3'
-import { bunServe, type ServerOptions } from '../../../serve.js'
+import { bunServe, type Callback, type ServerOptions } from '../../../serve.js'
 import { toWebHandler } from 'h3'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
-  bunServe(options, toWebHandler(app))
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptions,
+  callback?: Callback
+) {
+  bunServe(options, toWebHandler(app), callback)
 
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/bun/hattip.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/bun/hattip.ts
@@ -1,24 +1,32 @@
 import type { apply as applyAdapter } from '@universal-middleware/hattip'
-import { bunServe, type ServerOptions } from '../../../serve.js'
+import { bunServe, type Callback, type ServerOptions } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptions,
+  callback?: Callback
+) {
   const handler = app.buildHandler()
-  bunServe(options, (request) => {
-    return handler({
-      request,
-      ip: '',
-      passThrough() {
-        // No op
-      },
-      waitUntil() {
-        // No op
-      },
-      platform: { name: 'bun' },
-      env(variable: string) {
-        return process.env[variable]
-      }
-    })
-  })
+  bunServe(
+    options,
+    (request) => {
+      return handler({
+        request,
+        ip: '',
+        passThrough() {
+          // No op
+        },
+        waitUntil() {
+          // No op
+        },
+        platform: { name: 'bun' },
+        env(variable: string) {
+          return process.env[variable]
+        }
+      })
+    },
+    callback
+  )
 
   return handler
 }

--- a/packages/vike-server/src/handlers/adapters/serve/bun/hono.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/bun/hono.ts
@@ -1,9 +1,13 @@
 import type { apply as applyAdapter } from '@universal-middleware/hono'
-import { bunServe } from '../../../serve.js'
+import { bunServe, type Callback } from '../../../serve.js'
 import type { MergedHonoServerOptions } from '../hono-types.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: MergedHonoServerOptions) {
-  bunServe(options, app.fetch)
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: MergedHonoServerOptions,
+  callback?: Callback
+) {
+  bunServe(options, app.fetch, callback)
 
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/deno/elysia.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/deno/elysia.ts
@@ -1,8 +1,12 @@
 import type { apply as applyAdapter } from '@universal-middleware/elysia'
-import { denoServe, type ServerOptionsBase } from '../../../serve.js'
+import { type Callback, denoServe, type ServerOptionsBase } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptionsBase) {
-  denoServe(options, app.fetch)
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptionsBase,
+  callback?: Callback
+) {
+  denoServe(options, app.fetch, callback)
 
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/deno/h3.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/deno/h3.ts
@@ -1,9 +1,13 @@
 import type { apply as applyAdapter } from '@universal-middleware/h3'
-import { denoServe, type ServerOptions } from '../../../serve.js'
+import { type Callback, denoServe, type ServerOptions } from '../../../serve.js'
 import { toWebHandler } from 'h3'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
-  denoServe(options, toWebHandler(app))
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptions,
+  callback?: Callback
+) {
+  denoServe(options, toWebHandler(app), callback)
 
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/deno/hattip.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/deno/hattip.ts
@@ -1,24 +1,32 @@
 import type { apply as applyAdapter } from '@universal-middleware/hattip'
-import { denoServe, type ServerOptions } from '../../../serve.js'
+import { type Callback, denoServe, type ServerOptions } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptions,
+  callback?: Callback
+) {
   const handler = app.buildHandler()
-  denoServe(options, (request) => {
-    return handler({
-      request,
-      ip: '',
-      passThrough() {
-        // No op
-      },
-      waitUntil() {
-        // No op
-      },
-      platform: { name: 'bun' },
-      env(variable: string) {
-        return process.env[variable]
-      }
-    })
-  })
+  denoServe(
+    options,
+    (request) => {
+      return handler({
+        request,
+        ip: '',
+        passThrough() {
+          // No op
+        },
+        waitUntil() {
+          // No op
+        },
+        platform: { name: 'bun' },
+        env(variable: string) {
+          return process.env[variable]
+        }
+      })
+    },
+    callback
+  )
 
   return handler
 }

--- a/packages/vike-server/src/handlers/adapters/serve/deno/hono.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/deno/hono.ts
@@ -1,9 +1,13 @@
 import type { apply as applyAdapter } from '@universal-middleware/hono'
-import { denoServe } from '../../../serve.js'
+import { type Callback, denoServe } from '../../../serve.js'
 import type { MergedHonoServerOptions } from '../hono-types.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: MergedHonoServerOptions) {
-  denoServe(options, app.fetch)
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: MergedHonoServerOptions,
+  callback?: Callback
+) {
+  denoServe(options, app.fetch, callback)
 
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/elysia.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/elysia.ts
@@ -1,6 +1,10 @@
 import type { apply as applyAdapter } from '@universal-middleware/elysia'
-import type { ServerOptionsBase } from '../../serve.js'
+import type { Callback, ServerOptionsBase } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: ServerOptionsBase) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  _options: ServerOptionsBase,
+  _callback?: Callback
+) {
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/express.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/express.ts
@@ -1,6 +1,10 @@
 import type { apply as applyAdapter } from '@universal-middleware/express'
-import type { ServerOptions } from '../../serve.js'
+import type { Callback, ServerOptions } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: ServerOptions) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  _options: ServerOptions,
+  _callback?: Callback
+) {
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/fastify.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/fastify.ts
@@ -1,6 +1,10 @@
 import type { apply as applyAdapter } from '@universal-middleware/fastify'
-import type { ServerOptionsBase } from '../../serve.js'
+import type { Callback, ServerOptionsBase } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: ServerOptionsBase) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  _options: ServerOptionsBase,
+  _callback?: Callback
+) {
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/h3.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/h3.ts
@@ -1,6 +1,10 @@
 import type { apply as applyAdapter } from '@universal-middleware/h3'
-import type { ServerOptions } from '../../serve.js'
+import type { Callback, ServerOptions } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: ServerOptions) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  _options: ServerOptions,
+  _callback?: Callback
+) {
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/hattip.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/hattip.ts
@@ -1,6 +1,10 @@
 import type { apply as applyAdapter } from '@universal-middleware/hattip'
-import type { ServerOptions } from '../../serve.js'
+import type { Callback, ServerOptions } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: ServerOptions) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  _options: ServerOptions,
+  _callback?: Callback
+) {
   return app.buildHandler()
 }

--- a/packages/vike-server/src/handlers/adapters/serve/hono.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/hono.ts
@@ -1,6 +1,11 @@
 import type { apply as applyAdapter } from '@universal-middleware/hono'
 import type { MergedHonoServerOptions } from './hono-types.js'
+import type { Callback } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: MergedHonoServerOptions) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  _options: MergedHonoServerOptions,
+  _callback?: Callback
+) {
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/node/elysia.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/elysia.ts
@@ -1,9 +1,13 @@
 import type { apply as applyAdapter } from '@universal-middleware/elysia'
-import { onReady, type ServerOptionsBase } from '../../../serve.js'
+import { type Callback, onReady, type ServerOptionsBase } from '../../../serve.js'
 import { Elysia } from 'elysia'
 import { node } from '@elysiajs/node'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptionsBase) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptionsBase,
+  callback?: Callback
+) {
   // TODO HMR
-  return new Elysia({ adapter: node() }).mount(app).listen(options.port, onReady(options))
+  return new Elysia({ adapter: node() }).mount(app).listen(options.port, onReady({ callback, ...options }))
 }

--- a/packages/vike-server/src/handlers/adapters/serve/node/express.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/express.ts
@@ -1,11 +1,15 @@
 import type { apply as applyAdapter } from '@universal-middleware/express'
-import { installServerHMR, nodeServe, type ServerOptions } from '../../../serve.js'
+import { type Callback, installServerHMR, nodeServe, type ServerOptions } from '../../../serve.js'
 import { createServer } from 'node:http'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptions,
+  callback?: Callback
+) {
   if (!options.createServer) options.createServer = createServer
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  const _serve = () => nodeServe(options, app as any)
+  const _serve = () => nodeServe(options, app as any, callback)
 
   if (import.meta.hot) {
     installServerHMR(_serve)

--- a/packages/vike-server/src/handlers/adapters/serve/node/fastify.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/fastify.ts
@@ -1,14 +1,18 @@
 import pc from '@brillout/picocolors'
 import type { apply as applyAdapter } from '@universal-middleware/fastify'
-import { installServerHMR, onReady, type ServerOptionsBase } from '../../../serve.js'
+import { type Callback, installServerHMR, onReady, type ServerOptionsBase } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptionsBase) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptionsBase,
+  callback?: Callback
+) {
   const _serve = () => {
     app.listen(
       {
         port: options.port
       },
-      onReady(options)
+      onReady({ callback, ...options })
     )
     return app.server
   }

--- a/packages/vike-server/src/handlers/adapters/serve/node/h3.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/h3.ts
@@ -1,11 +1,15 @@
 import type { apply as applyAdapter } from '@universal-middleware/h3'
 import { createServer } from 'node:http'
 import { toNodeListener } from 'h3'
-import { installServerHMR, type NodeHandler, nodeServe, type ServerOptions } from '../../../serve.js'
+import { type Callback, installServerHMR, type NodeHandler, nodeServe, type ServerOptions } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptions,
+  callback?: Callback
+) {
   if (!options.createServer) options.createServer = createServer
-  const _serve = () => nodeServe(options, toNodeListener(app) as NodeHandler)
+  const _serve = () => nodeServe(options, toNodeListener(app) as NodeHandler, callback)
 
   if (import.meta.hot) {
     installServerHMR(_serve)

--- a/packages/vike-server/src/handlers/adapters/serve/node/hattip.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/hattip.ts
@@ -1,13 +1,17 @@
 import type { apply as applyAdapter } from '@universal-middleware/hattip'
-import { installServerHMR, type NodeHandler, nodeServe, type ServerOptions } from '../../../serve.js'
+import { type Callback, installServerHMR, type NodeHandler, nodeServe, type ServerOptions } from '../../../serve.js'
 import { createMiddleware } from '@hattip/adapter-node'
 import { createServer } from 'node:http'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: ServerOptions,
+  callback?: Callback
+) {
   if (!options.createServer) options.createServer = createServer
   const handler = app.buildHandler()
   const listener = createMiddleware(handler)
-  const _serve = () => nodeServe(options, listener as NodeHandler)
+  const _serve = () => nodeServe(options, listener as NodeHandler, callback)
 
   if (import.meta.hot) {
     installServerHMR(_serve)

--- a/packages/vike-server/src/handlers/adapters/serve/node/hono.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/hono.ts
@@ -1,9 +1,13 @@
 import type { apply as applyAdapter } from '@universal-middleware/hono'
 import { serve as honoServe } from '@hono/node-server'
-import { installServerHMR, onReady } from '../../../serve.js'
+import { type Callback, installServerHMR, onReady } from '../../../serve.js'
 import type { HonoServerOptions, MergedHonoServerOptions } from '../hono-types.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: MergedHonoServerOptions) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(
+  app: App,
+  options: MergedHonoServerOptions,
+  callback?: Callback
+) {
   const serverOptions = options.serverOptions ?? {}
   const isHttps = Boolean('cert' in serverOptions && serverOptions.cert)
   function _serve() {
@@ -13,7 +17,7 @@ export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, 
         ...(options as HonoServerOptions),
         fetch: app.fetch
       },
-      onReady({ isHttps, ...options })
+      onReady({ isHttps, callback, ...options })
     )
   }
 


### PR DESCRIPTION
### Example

```ts
import { Hono } from 'hono'
import { apply } from 'vike-server/hono'
import { serve } from 'vike-server/hono/serve'

async function startServer() {
  const app = new Hono()
  const port = process.env.PORT || 3000

  apply(app)

  return serve(app, { port: +port }, () => console.log('Server is ready!'))
}

export default startServer()
```