### PR TITLE
feat: move callback to onReady option

### DIFF
--- a/packages/vike-server/src/handlers/adapters/serve/bun/elysia.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/bun/elysia.ts
@@ -1,10 +1,6 @@
 import type { apply as applyAdapter } from '@universal-middleware/elysia'
-import { type Callback, onReady, type ServerOptionsBase } from '../../../serve.js'
+import { onReady, type ServerOptionsBase } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptionsBase,
-  callback?: Callback
-) {
-  return app.listen(options.port, onReady({ callback, ...options }))
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptionsBase) {
+  return app.listen(options.port, onReady(options))
 }

--- a/packages/vike-server/src/handlers/adapters/serve/bun/h3.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/bun/h3.ts
@@ -1,13 +1,9 @@
 import type { apply as applyAdapter } from '@universal-middleware/h3'
-import { bunServe, type Callback, type ServerOptions } from '../../../serve.js'
+import { bunServe, type ServerOptions } from '../../../serve.js'
 import { toWebHandler } from 'h3'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptions,
-  callback?: Callback
-) {
-  bunServe(options, toWebHandler(app), callback)
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
+  bunServe(options, toWebHandler(app))
 
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/bun/hattip.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/bun/hattip.ts
@@ -1,32 +1,24 @@
 import type { apply as applyAdapter } from '@universal-middleware/hattip'
-import { bunServe, type Callback, type ServerOptions } from '../../../serve.js'
+import { bunServe, type ServerOptions } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptions,
-  callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
   const handler = app.buildHandler()
-  bunServe(
-    options,
-    (request) => {
-      return handler({
-        request,
-        ip: '',
-        passThrough() {
-          // No op
-        },
-        waitUntil() {
-          // No op
-        },
-        platform: { name: 'bun' },
-        env(variable: string) {
-          return process.env[variable]
-        }
-      })
-    },
-    callback
-  )
+  bunServe(options, (request) => {
+    return handler({
+      request,
+      ip: '',
+      passThrough() {
+        // No op
+      },
+      waitUntil() {
+        // No op
+      },
+      platform: { name: 'bun' },
+      env(variable: string) {
+        return process.env[variable]
+      }
+    })
+  })
 
   return handler
 }

--- a/packages/vike-server/src/handlers/adapters/serve/bun/hono.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/bun/hono.ts
@@ -1,13 +1,9 @@
 import type { apply as applyAdapter } from '@universal-middleware/hono'
-import { bunServe, type Callback } from '../../../serve.js'
+import { bunServe } from '../../../serve.js'
 import type { MergedHonoServerOptions } from '../hono-types.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: MergedHonoServerOptions,
-  callback?: Callback
-) {
-  bunServe(options, app.fetch, callback)
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: MergedHonoServerOptions) {
+  bunServe(options, app.fetch)
 
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/deno/elysia.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/deno/elysia.ts
@@ -1,12 +1,8 @@
 import type { apply as applyAdapter } from '@universal-middleware/elysia'
-import { type Callback, denoServe, type ServerOptionsBase } from '../../../serve.js'
+import { denoServe, type ServerOptionsBase } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptionsBase,
-  callback?: Callback
-) {
-  denoServe(options, app.fetch, callback)
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptionsBase) {
+  denoServe(options, app.fetch)
 
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/deno/h3.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/deno/h3.ts
@@ -1,13 +1,9 @@
 import type { apply as applyAdapter } from '@universal-middleware/h3'
-import { type Callback, denoServe, type ServerOptions } from '../../../serve.js'
+import { denoServe, type ServerOptions } from '../../../serve.js'
 import { toWebHandler } from 'h3'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptions,
-  callback?: Callback
-) {
-  denoServe(options, toWebHandler(app), callback)
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
+  denoServe(options, toWebHandler(app))
 
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/deno/hattip.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/deno/hattip.ts
@@ -1,32 +1,24 @@
 import type { apply as applyAdapter } from '@universal-middleware/hattip'
-import { type Callback, denoServe, type ServerOptions } from '../../../serve.js'
+import { denoServe, type ServerOptions } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptions,
-  callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
   const handler = app.buildHandler()
-  denoServe(
-    options,
-    (request) => {
-      return handler({
-        request,
-        ip: '',
-        passThrough() {
-          // No op
-        },
-        waitUntil() {
-          // No op
-        },
-        platform: { name: 'bun' },
-        env(variable: string) {
-          return process.env[variable]
-        }
-      })
-    },
-    callback
-  )
+  denoServe(options, (request) => {
+    return handler({
+      request,
+      ip: '',
+      passThrough() {
+        // No op
+      },
+      waitUntil() {
+        // No op
+      },
+      platform: { name: 'bun' },
+      env(variable: string) {
+        return process.env[variable]
+      }
+    })
+  })
 
   return handler
 }

--- a/packages/vike-server/src/handlers/adapters/serve/deno/hono.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/deno/hono.ts
@@ -1,13 +1,9 @@
 import type { apply as applyAdapter } from '@universal-middleware/hono'
-import { type Callback, denoServe } from '../../../serve.js'
+import { denoServe } from '../../../serve.js'
 import type { MergedHonoServerOptions } from '../hono-types.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: MergedHonoServerOptions,
-  callback?: Callback
-) {
-  denoServe(options, app.fetch, callback)
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: MergedHonoServerOptions) {
+  denoServe(options, app.fetch)
 
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/elysia.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/elysia.ts
@@ -1,10 +1,6 @@
 import type { apply as applyAdapter } from '@universal-middleware/elysia'
-import type { Callback, ServerOptionsBase } from '../../serve.js'
+import type { ServerOptionsBase } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  _options: ServerOptionsBase,
-  _callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: ServerOptionsBase) {
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/express.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/express.ts
@@ -1,10 +1,6 @@
 import type { apply as applyAdapter } from '@universal-middleware/express'
-import type { Callback, ServerOptions } from '../../serve.js'
+import type { ServerOptions } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  _options: ServerOptions,
-  _callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: ServerOptions) {
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/fastify.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/fastify.ts
@@ -1,10 +1,6 @@
 import type { apply as applyAdapter } from '@universal-middleware/fastify'
-import type { Callback, ServerOptionsBase } from '../../serve.js'
+import type { ServerOptionsBase } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  _options: ServerOptionsBase,
-  _callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: ServerOptionsBase) {
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/h3.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/h3.ts
@@ -1,10 +1,6 @@
 import type { apply as applyAdapter } from '@universal-middleware/h3'
-import type { Callback, ServerOptions } from '../../serve.js'
+import type { ServerOptions } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  _options: ServerOptions,
-  _callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: ServerOptions) {
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/hattip.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/hattip.ts
@@ -1,10 +1,6 @@
 import type { apply as applyAdapter } from '@universal-middleware/hattip'
-import type { Callback, ServerOptions } from '../../serve.js'
+import type { ServerOptions } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  _options: ServerOptions,
-  _callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: ServerOptions) {
   return app.buildHandler()
 }

--- a/packages/vike-server/src/handlers/adapters/serve/hono.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/hono.ts
@@ -1,11 +1,6 @@
 import type { apply as applyAdapter } from '@universal-middleware/hono'
 import type { MergedHonoServerOptions } from './hono-types.js'
-import type { Callback } from '../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  _options: MergedHonoServerOptions,
-  _callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, _options: MergedHonoServerOptions) {
   return app
 }

--- a/packages/vike-server/src/handlers/adapters/serve/node/elysia.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/elysia.ts
@@ -1,13 +1,9 @@
 import type { apply as applyAdapter } from '@universal-middleware/elysia'
-import { type Callback, onReady, type ServerOptionsBase } from '../../../serve.js'
+import { onReady, type ServerOptionsBase } from '../../../serve.js'
 import { Elysia } from 'elysia'
 import { node } from '@elysiajs/node'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptionsBase,
-  callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptionsBase) {
   // TODO HMR
-  return new Elysia({ adapter: node() }).mount(app).listen(options.port, onReady({ callback, ...options }))
+  return new Elysia({ adapter: node() }).mount(app).listen(options.port, onReady(options))
 }

--- a/packages/vike-server/src/handlers/adapters/serve/node/express.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/express.ts
@@ -1,15 +1,11 @@
 import type { apply as applyAdapter } from '@universal-middleware/express'
-import { type Callback, installServerHMR, nodeServe, type ServerOptions } from '../../../serve.js'
+import { installServerHMR, nodeServe, type ServerOptions } from '../../../serve.js'
 import { createServer } from 'node:http'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptions,
-  callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
   if (!options.createServer) options.createServer = createServer
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  const _serve = () => nodeServe(options, app as any, callback)
+  const _serve = () => nodeServe(options, app as any)
 
   if (import.meta.hot) {
     installServerHMR(_serve)

--- a/packages/vike-server/src/handlers/adapters/serve/node/fastify.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/fastify.ts
@@ -1,18 +1,14 @@
 import pc from '@brillout/picocolors'
 import type { apply as applyAdapter } from '@universal-middleware/fastify'
-import { type Callback, installServerHMR, onReady, type ServerOptionsBase } from '../../../serve.js'
+import { installServerHMR, onReady, type ServerOptionsBase } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptionsBase,
-  callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptionsBase) {
   const _serve = () => {
     app.listen(
       {
         port: options.port
       },
-      onReady({ callback, ...options })
+      onReady(options)
     )
     return app.server
   }

--- a/packages/vike-server/src/handlers/adapters/serve/node/h3.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/h3.ts
@@ -1,15 +1,11 @@
 import type { apply as applyAdapter } from '@universal-middleware/h3'
 import { createServer } from 'node:http'
 import { toNodeListener } from 'h3'
-import { type Callback, installServerHMR, type NodeHandler, nodeServe, type ServerOptions } from '../../../serve.js'
+import { installServerHMR, type NodeHandler, nodeServe, type ServerOptions } from '../../../serve.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptions,
-  callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
   if (!options.createServer) options.createServer = createServer
-  const _serve = () => nodeServe(options, toNodeListener(app) as NodeHandler, callback)
+  const _serve = () => nodeServe(options, toNodeListener(app) as NodeHandler)
 
   if (import.meta.hot) {
     installServerHMR(_serve)

--- a/packages/vike-server/src/handlers/adapters/serve/node/hattip.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/hattip.ts
@@ -1,17 +1,13 @@
 import type { apply as applyAdapter } from '@universal-middleware/hattip'
-import { type Callback, installServerHMR, type NodeHandler, nodeServe, type ServerOptions } from '../../../serve.js'
+import { installServerHMR, type NodeHandler, nodeServe, type ServerOptions } from '../../../serve.js'
 import { createMiddleware } from '@hattip/adapter-node'
 import { createServer } from 'node:http'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: ServerOptions,
-  callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: ServerOptions) {
   if (!options.createServer) options.createServer = createServer
   const handler = app.buildHandler()
   const listener = createMiddleware(handler)
-  const _serve = () => nodeServe(options, listener as NodeHandler, callback)
+  const _serve = () => nodeServe(options, listener as NodeHandler)
 
   if (import.meta.hot) {
     installServerHMR(_serve)

--- a/packages/vike-server/src/handlers/adapters/serve/node/hono.ts
+++ b/packages/vike-server/src/handlers/adapters/serve/node/hono.ts
@@ -1,23 +1,20 @@
 import type { apply as applyAdapter } from '@universal-middleware/hono'
 import { serve as honoServe } from '@hono/node-server'
-import { type Callback, installServerHMR, onReady } from '../../../serve.js'
-import type { HonoServerOptions, MergedHonoServerOptions } from '../hono-types.js'
+import { installServerHMR, onReady } from '../../../serve.js'
+import type { MergedHonoServerOptions } from '../hono-types.js'
 
-export function serve<App extends Parameters<typeof applyAdapter>[0]>(
-  app: App,
-  options: MergedHonoServerOptions,
-  callback?: Callback
-) {
+export function serve<App extends Parameters<typeof applyAdapter>[0]>(app: App, options: MergedHonoServerOptions) {
   const serverOptions = options.serverOptions ?? {}
   const isHttps = Boolean('cert' in serverOptions && serverOptions.cert)
   function _serve() {
     return honoServe(
       {
-        overrideGlobalObjects: false,
-        ...(options as HonoServerOptions),
+        overrideGlobalObjects: options?.overrideGlobalObjects ?? false,
+        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        ...(options as any),
         fetch: app.fetch
       },
-      onReady({ isHttps, callback, ...options })
+      onReady({ isHttps, ...options })
     )
   }
 

--- a/packages/vike-server/src/handlers/serve.ts
+++ b/packages/vike-server/src/handlers/serve.ts
@@ -38,7 +38,16 @@ interface ServerOptionsHTTP2Base {
 }
 
 export interface ServerOptionsBase {
+  /**
+   * Server port
+   */
   port: number
+  /**
+   * Callback triggered when the server is listening for connections.
+   * By default, it prints a message to the console.
+   * Can be disabled by setting this to `false`
+   */
+  onReady: Callback
   bun?: Omit<Parameters<typeof Bun.serve>[0], 'fetch' | 'port'>
   deno?: Omit<Deno.ServeTcpOptions | (Deno.ServeTcpOptions & Deno.TlsCertifiedKeyPem), 'port' | 'handler'>
 }

--- a/packages/vike-server/src/handlers/serve.ts
+++ b/packages/vike-server/src/handlers/serve.ts
@@ -62,7 +62,7 @@ export interface NodeHandler {
   (req: Http2ServerRequest, res: Http2ServerResponse, next?: (err?: unknown) => void): void
 }
 
-export function onReady(options: { port: number; isHttps?: boolean; callback?: boolean | Callback }) {
+export function onReady(options: { port: number; isHttps?: boolean; onReady?: Callback }) {
   return () => {
     if (import.meta.hot) {
       if (import.meta.hot.data.vikeServerStarted) {
@@ -71,36 +71,36 @@ export function onReady(options: { port: number; isHttps?: boolean; callback?: b
       }
       import.meta.hot.data.vikeServerStarted = true
     }
-    if (options?.callback === true || options?.callback === undefined) {
+    if (options?.onReady === true || options?.onReady === undefined) {
       console.log(`Server running at ${options.isHttps ? 'https' : 'http'}://localhost:${options.port}`)
-    } else if (typeof options?.callback === 'function') {
-      options.callback()
+    } else if (typeof options?.onReady === 'function') {
+      options.onReady()
     }
   }
 }
 
-export function nodeServe(options: ServerOptions, handler: NodeHandler, callback?: Callback): ServerType {
+export function nodeServe(options: ServerOptions, handler: NodeHandler): ServerType {
   assert(options.createServer)
   const serverOptions = options.serverOptions ?? {}
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   const createServer: any = options.createServer
   const server: ServerType = createServer(serverOptions, handler)
   const isHttps = Boolean('cert' in serverOptions && serverOptions.cert)
-  server.listen(options.port, onReady({ isHttps, callback, ...options }))
+  server.listen(options.port, onReady({ isHttps, ...options }))
   return server
 }
 
-export function denoServe(options: ServerOptions, handler: Handler, callback?: Callback) {
+export function denoServe(options: ServerOptions, handler: Handler) {
   const denoOptions = options.deno ?? {}
   const isHttps = 'cert' in denoOptions ? Boolean(denoOptions.cert) : false
-  Deno.serve({ ...denoOptions, port: options.port, onListen: onReady({ isHttps, callback, ...options }) }, handler)
+  Deno.serve({ ...denoOptions, port: options.port, onListen: onReady({ isHttps, ...options }) }, handler)
 }
 
-export function bunServe(options: ServerOptions, handler: Handler, callback?: Callback) {
+export function bunServe(options: ServerOptions, handler: Handler) {
   const bunOptions = options.bun ?? {}
   const isHttps = 'tls' in bunOptions ? Boolean(bunOptions.tls) : false
   Bun.serve({ ...options.bun, port: options.port, fetch: handler } as Parameters<typeof Bun.serve>[0])
-  onReady({ isHttps, callback, ...options })()
+  onReady({ isHttps, ...options })()
 }
 
 /**

--- a/packages/vike-server/src/handlers/serve.ts
+++ b/packages/vike-server/src/handlers/serve.ts
@@ -47,7 +47,7 @@ export interface ServerOptionsBase {
    * By default, it prints a message to the console.
    * Can be disabled by setting this to `false`
    */
-  onReady: Callback
+  onReady?: Callback
   bun?: Omit<Parameters<typeof Bun.serve>[0], 'fetch' | 'port'>
   deno?: Omit<Deno.ServeTcpOptions | (Deno.ServeTcpOptions & Deno.TlsCertifiedKeyPem), 'port' | 'handler'>
 }

--- a/test/vike-server/.dev-elysia.test.ts
+++ b/test/vike-server/.dev-elysia.test.ts
@@ -2,4 +2,4 @@ process.env.VIKE_NODE_FRAMEWORK = 'elysia'
 
 import { testRun } from './.testRun'
 
-testRun('pnpm run dev', { skipServerHMR: true })
+testRun('pnpm run dev', { skipServerHMR: true, isFlaky: true })

--- a/test/vike-server/.testRun.ts
+++ b/test/vike-server/.testRun.ts
@@ -15,8 +15,14 @@ import {
   test
 } from '@brillout/test-e2e'
 
-function testRun(cmd: 'pnpm run dev' | 'pnpm run prod', options?: { skipServerHMR?: boolean; https?: boolean }) {
-  run(cmd, { serverUrl: options?.https ? 'https://localhost:3000' : 'http://127.0.0.1:3000' })
+function testRun(
+  cmd: 'pnpm run dev' | 'pnpm run prod',
+  options?: { skipServerHMR?: boolean; https?: boolean; isFlaky?: boolean }
+) {
+  run(cmd, {
+    serverUrl: options?.https ? 'https://localhost:3000' : 'http://127.0.0.1:3000',
+    isFlaky: options?.isFlaky
+  })
   const entry = `./server/index-${process.env.VIKE_NODE_FRAMEWORK || 'hono'}.ts`
   const isProd = cmd === 'pnpm run prod'
 


### PR DESCRIPTION
### Example

```ts
import { Hono } from 'hono'
import { apply } from 'vike-server/hono'
import { serve } from 'vike-server/hono/serve'

async function startServer() {
  const app = new Hono()
  const port = process.env.PORT || 3000

  apply(app)

  return serve(app, {
    port: +port,
    onReady() {
      console.log('Server is ready!')
    }
  })
}

export default startServer()
```